### PR TITLE
Refactor transactions.ts module and memoize the externalNonce2Tx function

### DIFF
--- a/packages/transactions/src/callHelpersContextParametrized.ts
+++ b/packages/transactions/src/callHelpersContextParametrized.ts
@@ -3,7 +3,7 @@ import { combineLatest, from, Observable } from 'rxjs';
 import { first, map, switchMap } from 'rxjs/internal/operators';
 import Web3 from 'web3';
 
-import { SendFunction, TxMeta, TxState } from './transactions';
+import { SendFunction, TxMeta, TxState } from './types';
 
 type GasPrice$ = Observable<BigNumber>;
 export const DEFAULT_GAS = 6000000;

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -10,5 +10,6 @@ export {
   estimateGas,
   call,
 } from './callHelpersContextParametrized';
-export type { TxState, TxMeta, SendFunction, TxRebroadcastStatus } from './transactions';
-export { TxStatus, createSend, isDone } from './transactions';
+export type { TxState, TxMeta, SendFunction, TxRebroadcastStatus } from './types';
+export { TxStatus } from './types';
+export { createSend, isDone } from './transactions';

--- a/packages/transactions/src/serialization.ts
+++ b/packages/transactions/src/serialization.ts
@@ -1,0 +1,41 @@
+import BigNumber from 'bignumber.js';
+import { TxMeta, TxState, TxStatus } from './types';
+
+// By default - toJSON method returns a string and we override it with our implementation that
+// returns other type so we need to ignore the error
+// eslint-disable-next-line
+// @ts-ignore
+BigNumber.prototype.toJSON = function toJSON() {
+  return {
+    _type: 'BigNumber',
+    _data: Object.assign({}, this),
+  };
+};
+
+function reviveFromJSON(_key: string, value: any) {
+  if (typeof value === 'object' && value !== null && value.hasOwnProperty('_type')) {
+    switch (value._type) {
+      case 'BigNumber':
+        return Object.assign(new BigNumber(0), value._data);
+    }
+  }
+  const reISO = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
+  if (reISO.exec(value)) return new Date(value);
+  return value;
+}
+
+export function deserializeTransactions<A extends TxMeta>(
+  serializedTransactions: string,
+): TxState<A>[] {
+  return JSON.parse(serializedTransactions, reviveFromJSON);
+}
+
+export function serializeTransactions<A extends TxMeta>(transactions: TxState<A>[]): string {
+  console.log('serialize', transactions);
+  return JSON.stringify(
+    transactions.filter(
+      (tx) =>
+        tx.status !== TxStatus.CancelledByTheUser && tx.status !== TxStatus.WaitingForApproval,
+    ),
+  );
+}

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -1,0 +1,140 @@
+import Web3 from 'web3';
+import BigNumber from 'bignumber.js';
+import { Observable } from 'rxjs';
+
+export interface CommonContext {
+  id: string;
+  etherscan: {
+    apiUrl: string;
+    apiKey: string;
+  };
+  safeConfirmations: number;
+  web3: Web3;
+}
+
+export type TxMeta = {
+  kind: any;
+  [key: string]: string | number | boolean | BigNumber | undefined;
+};
+
+export enum TxStatus {
+  WaitingForApproval = 'WaitingForApproval',
+  CancelledByTheUser = 'CancelledByTheUser',
+  Propagating = 'Propagating',
+  WaitingForConfirmation = 'WaitingForConfirmation',
+  Success = 'Success',
+  Error = 'Error',
+  Failure = 'Failure',
+}
+
+export enum TxRebroadcastStatus {
+  speedup = 'speedup',
+  cancel = 'cancel',
+  lost = 'lost',
+}
+
+export type CommonTxState<A extends TxMeta> = {
+  account: string;
+  txNo: number;
+  networkId: string;
+  meta: A;
+  start: Date;
+  end?: Date;
+  lastChange: Date;
+  dismissed: boolean;
+};
+
+export interface WaitingForConfirmationTxState {
+  status: TxStatus.WaitingForConfirmation;
+  txHash: string;
+  broadcastedAt: Date;
+}
+export interface PropagatingTxState {
+  status: TxStatus.Propagating;
+  txHash: string;
+  broadcastedAt: Date;
+}
+export interface WaitingForApprovalTxState {
+  status: TxStatus.WaitingForApproval;
+}
+export interface CancelledByTheUserTxState {
+  status: TxStatus.CancelledByTheUser;
+  error: any;
+}
+export interface SuccessTxState {
+  status: TxStatus.Success;
+  txHash: string;
+  blockNumber: number;
+  receipt: any;
+  confirmations: number;
+  safeConfirmations: number;
+  rebroadcast?: TxRebroadcastStatus;
+}
+export interface FailureTxState {
+  status: TxStatus.Failure;
+  txHash: string;
+  blockNumber: number;
+  receipt: any;
+}
+export interface ErrorTxState {
+  status: TxStatus.Error;
+  txHash: string;
+  error: any;
+}
+
+export type TxState<A extends TxMeta> = CommonTxState<A> &
+  (
+    | WaitingForConfirmationTxState
+    | PropagatingTxState
+    | WaitingForApprovalTxState
+    | CancelledByTheUserTxState
+    | SuccessTxState
+    | FailureTxState
+    | ErrorTxState
+  );
+
+type NodeCallback<I, R> = (i: I, callback: (err: any, r: R) => any) => any;
+
+export interface TransactionReceiptLike {
+  transactionHash: string;
+  status: boolean;
+  blockNumber: number;
+}
+
+export type GetTransactionReceipt = NodeCallback<string, TransactionReceiptLike>;
+
+export interface TransactionLike {
+  hash: string;
+  nonce: number;
+  input: string;
+  blockHash: string;
+}
+
+export type GetTransaction = NodeCallback<string, TransactionLike | null>;
+
+export interface NewTransactionChange<A extends TxMeta> {
+  kind: 'newTx';
+  state: TxState<A>;
+}
+
+export interface CachedTransactionChange<A extends TxMeta> {
+  kind: 'cachedTx';
+  state: TxState<A>;
+}
+
+export interface DismissedChange {
+  kind: 'dismissed';
+  txNo: number;
+}
+
+export type TransactionsChange<A extends TxMeta> =
+  | NewTransactionChange<A>
+  | DismissedChange
+  | CachedTransactionChange<A>;
+
+export type SendFunction<A extends TxMeta> = (
+  account: string,
+  networkId: string,
+  meta: A,
+  method: (...args: any[]) => any,
+) => Observable<TxState<A>>;


### PR DESCRIPTION
This PR:
* Memoizes the `externalNonce2Tx` function so that when the user submits multiple transactions - we ping `etherscan` only once per block, not once per block per transaction. https://github.com/OasisDEX/common/pull/9/files#diff-cef634a9deedae472b9961544c28c9332fcae9c47f2d70714b2c16de384694c2R122
* Refactors some parts. Gets rid of type errors and deprecated operators

I've tested it with the current borrow and it's working. I'll publish the packages after it gets merged.