### PR TITLE
bump gas estimation multiplier

### DIFF
--- a/packages/transactions/src/callHelpersContextParametrized.ts
+++ b/packages/transactions/src/callHelpersContextParametrized.ts
@@ -44,7 +44,7 @@ export function call<D, R, CC extends ContextConnected>(
 
 // we accommodate for the fact that blockchain state
 // can be different when tx execute and it can take more gas
-const GAS_ESTIMATION_MULTIPLIER = 1.3;
+const GAS_ESTIMATION_MULTIPLIER = 1.5;
 export function estimateGas<A extends TxMeta, CC extends ContextConnected>(
   context: CC,
   { call, prepareArgs, options }: TransactionDef<A, CC>,


### PR DESCRIPTION
This fix is due to underestimation of gas limit failing transactions for hardware wallets.

It is a blunt fix and a more strategic approach will be investigated

Also merging into refactor branch as there is currently typecheck issues on main

