### PR TITLE
FIX - add `executionPrice` back

### DIFF
--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/automation",
-  "version": "1.5.0-alpha.6",
+  "version": "1.5.0-alpha.7",
   "description": "The set of utilities for Oasis automation",
   "homepage": "https://github.com/OasisDEX/common#readme",
   "main": "lib/src/index.js",

--- a/packages/automation/src/mapping.ts
+++ b/packages/automation/src/mapping.ts
@@ -164,7 +164,7 @@ export const defaultCommandTypeMapping = {
     'uint256',
     'address',
   ],
-  [CommandContractType.AutoTakeProfitCommand]: ['uint256', 'uint16', 'uint32'],
+  [CommandContractType.AutoTakeProfitCommand]: ['uint256', 'uint16', 'uint256', 'uint32'],
   [CommandContractType.BasicBuyCommand]: [
     'uint256',
     'uint16',


### PR DESCRIPTION
```diff
- [CommandContractType.AutoTakeProfitCommand]: ['uint256', 'uint16', 'uint32'],
+ [CommandContractType.AutoTakeProfitCommand]: ['uint256', 'uint16', 'uint256', 'uint32'],
```
during previous update `uint256` for `executionPrice` was removed mistakenely.