### PR TITLE
:rocket: feat: add partial take profit triggers

### DIFF
--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisdex/automation",
   "packageManager": "yarn@1.22.21",
-  "version": "1.6.3",
+  "version": "1.6.4.alpha.1",
   "description": "The set of utilities for Oasis automation",
   "homepage": "https://github.com/OasisDEX/common#readme",
   "main": "lib/src/index.js",

--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisdex/automation",
   "packageManager": "yarn@1.22.21",
-  "version": "1.6.4-alpha.0",
+  "version": "1.6.4-alpha.1",
   "description": "The set of utilities for Oasis automation",
   "homepage": "https://github.com/OasisDEX/common#readme",
   "main": "lib/src/index.js",

--- a/packages/automation/package.json
+++ b/packages/automation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oasisdex/automation",
   "packageManager": "yarn@1.22.21",
-  "version": "1.6.4.alpha.1",
+  "version": "1.6.4-alpha.0",
   "description": "The set of utilities for Oasis automation",
   "homepage": "https://github.com/OasisDEX/common#readme",
   "main": "lib/src/index.js",

--- a/packages/automation/src/index.ts
+++ b/packages/automation/src/index.ts
@@ -14,6 +14,7 @@ export { getCommandAddresses, commandTypeJsonMapping } from './mapping';
 export {
   CommandContractType,
   TriggerType,
+  TrailingStopLossTriggers,
   TriggerGroupType,
   triggerTypeToCommandContractTypeMap,
 } from './types';

--- a/packages/automation/src/mapping.ts
+++ b/packages/automation/src/mapping.ts
@@ -196,6 +196,30 @@ export const commandTypeJsonMapping: Record<CommandContractType, string[]> = {
     'deviation',
     'maxBaseFeeInGwei',
   ],
+  [CommandContractType.DmaSparkPartialTakeProfitCommandV2]: [
+    'positionAddress',
+    'triggerType',
+    'maxCoverage',
+    'debtToken',
+    'collateralToken',
+    'operationName',
+    'executionLtv',
+    'targetLtv',
+    'deviation',
+    'closeToCollateral',
+  ],
+  [CommandContractType.DmaAavePartialTakeProfitCommandV2]: [
+    'positionAddress',
+    'triggerType',
+    'maxCoverage',
+    'debtToken',
+    'collateralToken',
+    'operationName',
+    'executionLtv',
+    'targetLtv',
+    'deviation',
+    'closeToCollateral',
+  ],
 };
 export const commandOffchainDataTypeJsonMapping: Partial<Record<CommandContractType, string[]>> = {
   [CommandContractType.DmaAaveTrailingStopLossCommandV2]: [
@@ -428,8 +452,8 @@ export const defaultCommandTypeMapping: Record<CommandContractType, ParamDefinit
     'address', // debtToken
     'address', // collateralToken
     'bytes32', // operationName
-    'uint256', // execCollRatio
-    'uint256', // targetCollRatio
+    'uint256', // execLtv
+    'uint256', // targetLtv
     'uint256', // maxBuyPrice
     'uint64', // deviation
     'uint32', // maxBaseFeeInGwei
@@ -441,8 +465,8 @@ export const defaultCommandTypeMapping: Record<CommandContractType, ParamDefinit
     'address', // debtToken
     'address', // collateralToken
     'bytes32', // operationName
-    'uint256', // execCollRatio
-    'uint256', // targetCollRatio
+    'uint256', // execLtv
+    'uint256', // targetLtv
     'uint256', // minSellPrice
     'uint64', // deviation
     'uint32', // maxBaseFeeInGwei
@@ -500,8 +524,8 @@ export const defaultCommandTypeMapping: Record<CommandContractType, ParamDefinit
     'address', // debtToken
     'address', // collateralToken
     'bytes32', // operationName
-    'uint256', // execCollRatio
-    'uint256', // targetCollRatio
+    'uint256', // execLtv
+    'uint256', // targetLtv
     'uint256', // maxBuyPrice
     'uint64', // deviation
     'uint32', // maxBaseFeeInGwei
@@ -513,11 +537,35 @@ export const defaultCommandTypeMapping: Record<CommandContractType, ParamDefinit
     'address', // debtToken
     'address', // collateralToken
     'bytes32', // operationName
-    'uint256', // execCollRatio
-    'uint256', // targetCollRatio
+    'uint256', // execLtv
+    'uint256', // targetLtv
     'uint256', // minSellPrice
     'uint64', // deviation
     'uint32', // maxBaseFeeInGwei
+  ],
+  [CommandContractType.DmaAavePartialTakeProfitCommandV2]: [
+    'address', //positionAddress
+    'uint16', // triggerType
+    'uint256', // maxCoverage
+    'address', // debtToken
+    'address', // collateralToken
+    'bytes32', // operationName
+    'uint256', // execLtv
+    'uint256', // targetLtv
+    'uint64', // deviation
+    'bool', // closeToCollateral
+  ],
+  [CommandContractType.DmaSparkPartialTakeProfitCommandV2]: [
+    'address', //positionAddress
+    'uint16', // triggerType
+    'uint256', // maxCoverage
+    'address', // debtToken
+    'address', // collateralToken
+    'bytes32', // operationName
+    'uint256', // execLtv
+    'uint256', // targetLtv
+    'uint64', // deviation
+    'bool', // closeToCollateral
   ],
 } as const;
 

--- a/packages/automation/src/mapping.ts
+++ b/packages/automation/src/mapping.ts
@@ -205,6 +205,7 @@ export const commandTypeJsonMapping: Record<CommandContractType, string[]> = {
     'operationName',
     'executionLtv',
     'targetLtv',
+    'excutionPrice',
     'deviation',
     'closeToCollateral',
   ],
@@ -217,6 +218,7 @@ export const commandTypeJsonMapping: Record<CommandContractType, string[]> = {
     'operationName',
     'executionLtv',
     'targetLtv',
+    'excutionPrice',
     'deviation',
     'closeToCollateral',
   ],
@@ -552,6 +554,7 @@ export const defaultCommandTypeMapping: Record<CommandContractType, ParamDefinit
     'bytes32', // operationName
     'uint256', // execLtv
     'uint256', // targetLtv
+    'uint256', // excutionPrice
     'uint64', // deviation
     'bool', // closeToCollateral
   ],
@@ -564,6 +567,7 @@ export const defaultCommandTypeMapping: Record<CommandContractType, ParamDefinit
     'bytes32', // operationName
     'uint256', // execLtv
     'uint256', // targetLtv
+    'uint256', // excutionPrice
     'uint64', // deviation
     'bool', // closeToCollateral
   ],

--- a/packages/automation/src/mapping.ts
+++ b/packages/automation/src/mapping.ts
@@ -207,7 +207,7 @@ export const commandTypeJsonMapping: Record<CommandContractType, string[]> = {
     'targetLtv',
     'excutionPrice',
     'deviation',
-    'closeToCollateral',
+    'withdrawToDebt',
   ],
   [CommandContractType.DmaAavePartialTakeProfitCommandV2]: [
     'positionAddress',
@@ -220,7 +220,7 @@ export const commandTypeJsonMapping: Record<CommandContractType, string[]> = {
     'targetLtv',
     'excutionPrice',
     'deviation',
-    'closeToCollateral',
+    'withdrawToDebt',
   ],
 };
 export const commandOffchainDataTypeJsonMapping: Partial<Record<CommandContractType, string[]>> = {

--- a/packages/automation/src/types.ts
+++ b/packages/automation/src/types.ts
@@ -29,6 +29,8 @@ export enum CommandContractType {
   DmaSparkTrailingStopLossCommandV2 = 'DmaSparkTrailingStopLossCommandV2',
   DmaSparkBasicBuyCommandV2 = 'DmaSparkBasicBuyCommandV2',
   DmaSparkBasicSellCommandV2 = 'DmaSparkBasicSellCommandV2',
+  DmaAavePartialTakeProfitCommandV2 = 'DmaAaveV3PartialTakeProfitCommandV2',
+  DmaSparkPartialTakeProfitCommandV2 = 'DmaSparkPartialTakeProfitCommandV2',
 }
 
 export enum TriggerType {
@@ -59,9 +61,13 @@ export enum TriggerType {
   DmaSparkStopLossToDebtV2 = 130,
   DmaSparkBasicBuyV2 = 131,
   DmaSparkBasicSellV2 = 132,
+  DmaAavePartialTakeProfitV2 = 133,
+  DmaSparkPartialTakeProfitV2 = 134,
   DmaAaveTrailingStopLossV2 = 10006,
   DmaSparkTrailingStopLossV2 = 10007,
 }
+
+export const TrailingStopLossTriggers = [TriggerType.DmaAaveTrailingStopLossV2, TriggerType.DmaSparkTrailingStopLossV2];
 
 export const triggerTypeToCommandContractTypeMap: Record<TriggerType, CommandContractType> = {
   [TriggerType.StopLossToCollateral]: CommandContractType.CloseCommand,
@@ -93,6 +99,8 @@ export const triggerTypeToCommandContractTypeMap: Record<TriggerType, CommandCon
   [TriggerType.DmaSparkTrailingStopLossV2]: CommandContractType.DmaSparkTrailingStopLossCommandV2,
   [TriggerType.DmaSparkBasicBuyV2]: CommandContractType.DmaSparkBasicBuyCommandV2,
   [TriggerType.DmaSparkBasicSellV2]: CommandContractType.DmaSparkBasicSellCommandV2,
+  [TriggerType.DmaAavePartialTakeProfitV2]: CommandContractType.DmaAavePartialTakeProfitCommandV2,
+  [TriggerType.DmaSparkPartialTakeProfitV2]: CommandContractType.DmaSparkPartialTakeProfitCommandV2,
 };
 
 export enum TriggerGroupType {


### PR DESCRIPTION
- add two new trigger types for aave nd spark
- add trigger data types and names
- add a convenient array including trailig stop loss trigger types